### PR TITLE
8: Throw InvalidAlgorithmParameterException on RSA KeyPair Generation with invalid public key size

### DIFF
--- a/src/intTest/java/com/oracle/test/integration/keypair/KeyPairGenNegativeTest.java
+++ b/src/intTest/java/com/oracle/test/integration/keypair/KeyPairGenNegativeTest.java
@@ -102,15 +102,27 @@ public class KeyPairGenNegativeTest {
         kpRsa.generateKeyPair();
     }
 
-    @Test(expected = ProviderException.class)
+    @Test(expected = InvalidAlgorithmParameterException.class)
+    public void initRsaPubExpNegative() throws Exception {
+        kpRsa.initialize(new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4.negate()));
+    }
+
+    @Test(expected = InvalidAlgorithmParameterException.class)
     public void initRsaPubExpEven() throws Exception {
-        kpRsa.initialize(new RSAKeyGenParameterSpec(2048, BigInteger.valueOf(8)));
+        kpRsa.initialize(new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4.add(BigInteger.ONE)));
         kpRsa.generateKeyPair();
     }
 
     @Test(expected = InvalidAlgorithmParameterException.class)
-    public void initRsaPubExpNegative() throws Exception {
-        kpRsa.initialize(new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4.negate()));
+    public void initRsaPubExpOddBelowPermittedRange() throws Exception { // Odd value outside range 2^16 < e < 2^256
+        kpRsa.initialize(new RSAKeyGenParameterSpec(2048, BigInteger.valueOf(2).pow(16).subtract(BigInteger.ONE)));
+        kpRsa.generateKeyPair();
+    }
+
+    @Test(expected = InvalidAlgorithmParameterException.class)
+    public void initRsaPubExpOddAbovePermittedRange() throws Exception { // Odd value outside range 2^16 < e < 2^256
+        kpRsa.initialize(new RSAKeyGenParameterSpec(2048, BigInteger.valueOf(2).pow(256).add(BigInteger.ONE)));
+        kpRsa.generateKeyPair();
     }
 
     @Test(expected = InvalidAlgorithmParameterException.class)

--- a/src/main/java/com/oracle/jipher/internal/spi/KeyPairGen.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/KeyPairGen.java
@@ -188,16 +188,22 @@ public abstract class KeyPairGen extends KeyPairGenerator {
                 throw new InvalidAlgorithmParameterException("invalid key size");
             }
             if (kgParams.getPublicExponent() != null) {
-                if (kgParams.getPublicExponent().signum() <= 0) {
-                    throw new InvalidAlgorithmParameterException("Parameter spec must not contain zero, or negative values");
+                BigInteger publicExponent = kgParams.getPublicExponent();
+
+                // FIPS 186-5 The exponent e shall be an odd positive integer such that 2^16 < e < 2^256
+                // Note: 2^16 is even so we don't need to worry about 2^16 having 17 bits.
+                if (publicExponent.signum() <= 0 || !publicExponent.testBit(0) ||
+                        publicExponent.bitLength() <= 16 || publicExponent.bitLength() >= 257) {
+                    throw new InvalidAlgorithmParameterException("Public exponent e must be an odd positive integer such that 2^16 < e < 2^256");
                 }
+
                 // If OpenSSL is directed to generate an RSA key pair using a modules with more than
                 // OPENSSL_RSA_SMALL_MODULUS_BITS and a public exponent with more than
                 // OPENSSL_RSA_MAX_PUBEXP_BITS it will fail the pair-wise consistency test resulting in the
                 // FIPS module entering an error state. We want to avoid this because the only way to clear
                 // the FIPS module error state is to unload and reload the FIPS module.
                 if (kgParams.getKeysize() > EVP_PKEY.RSA_SMALL_MODULUS_BITS &&
-                        kgParams.getPublicExponent().bitLength() > EVP_PKEY.RSA_MAX_PUBEXP_BITS) {
+                        publicExponent.bitLength() > EVP_PKEY.RSA_MAX_PUBEXP_BITS) {
                     throw new InvalidAlgorithmParameterException(String.format(
                             "Generating an RSA key with a length of more than %d bits and a public key exponent " +
                             "of more than %d bits is not supported.",


### PR DESCRIPTION
Explicitly perform public key validation according to FIPS 186 Appendix A.1 'IFC Key Pair Generation' and return the correct exception type when validation fails.

Testing has shown that otherwise the check can fail in OpenSSL causing an unexpected Exception type to be thrown.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [BRISBANE-8](https://bugs.openjdk.org/browse/BRISBANE-8): Throw InvalidAlgorithmParameterException on RSA KeyPair Generation with invalid public key size (**Bug** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/brisbane.git pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/3.diff">https://git.openjdk.org/brisbane/pull/3.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/3#issuecomment-4402709275)
</details>
