### PR TITLE
5: Support Generic algorithm in KeyAgreement.generateSecret(String)

### DIFF
--- a/src/intTest/java/com/oracle/test/integration/keyagree/KeyAgreeApiTest.java
+++ b/src/intTest/java/com/oracle/test/integration/keyagree/KeyAgreeApiTest.java
@@ -150,6 +150,24 @@ public class KeyAgreeApiTest {
     }
 
     @Test
+    public void generateSecretGeneric() throws Exception {
+        agree.init(priv);
+        agree.doPhase(pub, true);
+        assertArrayEquals(tv.getSecret(), agree.generateSecret("Generic").getEncoded());
+    }
+
+    @Test
+    public void generateSecretTlsPremasterSecret() throws Exception {
+        agree.init(priv);
+        agree.doPhase(pub, true);
+        // Trim leading zeroes if algorithm is DH
+        byte[] expectedSecret = (this.alg.equals("DH")) ?
+                TestUtil.trimLeadingZeros(tv.getSecret()) :
+                tv.getSecret();
+        assertArrayEquals(expectedSecret, agree.generateSecret("TlsPremasterSecret").getEncoded());
+    }
+
+    @Test
     public void generateSecretBuffer() throws Exception {
         agree.init(priv, null, null);
         agree.doPhase(pub, true);
@@ -165,12 +183,14 @@ public class KeyAgreeApiTest {
         } else if (algorithm.equalsIgnoreCase("DESede")) {
             SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance(algorithm, "SunJCE");
             return secretKeyFactory.generateSecret(new DESedeKeySpec(keyMaterial));
-        } else if  (algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
+        } else if (algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
             if (this.alg.equals("DH")) {
                 return new SecretKeySpec(TestUtil.trimLeadingZeros(keyMaterial), algorithm);
             } else {
                 return new SecretKeySpec(keyMaterial, algorithm);
             }
+        } else if (algorithm.equalsIgnoreCase("Generic")) {
+            return new SecretKeySpec(keyMaterial, algorithm);
         } else {
             throw new NoSuchAlgorithmException("Unsupported secret key algorithm: " + alg);
         }
@@ -198,8 +218,13 @@ public class KeyAgreeApiTest {
     }
 
     @Test
-    public void generateTlsPremasterSecrettKey() throws Exception {
+    public void generateTlsPremasterSecretKey() throws Exception {
         generateSecretKey("TlsPremasterSecret");
+    }
+
+    @Test
+    public void generateGenericKey() throws Exception {
+        generateSecretKey("Generic");
     }
 
     // Tests that once init has been called the keyagree object

--- a/src/main/java/com/oracle/jipher/internal/spi/KeyAgree.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/KeyAgree.java
@@ -141,7 +141,9 @@ public abstract class KeyAgree extends KeyAgreementSpi {
      * @param secret the secret key material to use
      * @return a {@link SecretKey} suitable for use by the JSSE
      */
-    abstract SecretKey createGenericSecretKey(byte[] secret);
+    SecretKey createGenericSecretKey(byte[] secret) {
+        return new SecretKeySpec(secret, "Generic");
+    }
 
     @Override
     protected void engineInit(Key key, AlgorithmParameterSpec algorithmParameterSpec, SecureRandom secureRandom)
@@ -317,11 +319,6 @@ public abstract class KeyAgree extends KeyAgreementSpi {
         SecretKey createTlsPremasterSecretKey(byte[] secret) {
             return new SecretKeySpec(secret, "TlsPremasterSecret");
         }
-
-        @Override
-        SecretKey createGenericSecretKey(byte[] secret) {
-            return new SecretKeySpec(secret, "Generic");
-        }
     }
 
     /**
@@ -368,11 +365,6 @@ public abstract class KeyAgree extends KeyAgreementSpi {
             } else {
                 return new SecretKeySpec(secret, "TlsPremasterSecret");
             }
-        }
-
-        @Override
-        SecretKey createGenericSecretKey(byte[] secret) {
-            return new SecretKeySpec(secret, "Generic");
         }
 
         boolean paramsEquals(DHParameterSpec spec1, DHParameterSpec spec2) {

--- a/src/main/java/com/oracle/jipher/internal/spi/KeyAgree.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/KeyAgree.java
@@ -136,6 +136,13 @@ public abstract class KeyAgree extends KeyAgreementSpi {
      */
     abstract SecretKey createTlsPremasterSecretKey(byte[] secret);
 
+    /**
+     * Creates a Generic Key from secret key material
+     * @param secret the secret key material to use
+     * @return a {@link SecretKey} suitable for use by the JSSE
+     */
+    abstract SecretKey createGenericSecretKey(byte[] secret);
+
     @Override
     protected void engineInit(Key key, AlgorithmParameterSpec algorithmParameterSpec, SecureRandom secureRandom)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
@@ -250,6 +257,8 @@ public abstract class KeyAgree extends KeyAgreementSpi {
                 return TripleDesUtil.createKey(this.state.secret);
             } else if (alg.equals("TlsPremasterSecret")) {
                 return createTlsPremasterSecretKey(this.state.secret);
+            } else if (alg.equals("Generic")) {
+                return createGenericSecretKey(this.state.secret);
             } else {
                 throw new NoSuchAlgorithmException("Unsupported secret key algorithm: " + alg);
             }
@@ -308,6 +317,11 @@ public abstract class KeyAgree extends KeyAgreementSpi {
         SecretKey createTlsPremasterSecretKey(byte[] secret) {
             return new SecretKeySpec(secret, "TlsPremasterSecret");
         }
+
+        @Override
+        SecretKey createGenericSecretKey(byte[] secret) {
+            return new SecretKeySpec(secret, "Generic");
+        }
     }
 
     /**
@@ -354,6 +368,11 @@ public abstract class KeyAgree extends KeyAgreementSpi {
             } else {
                 return new SecretKeySpec(secret, "TlsPremasterSecret");
             }
+        }
+
+        @Override
+        SecretKey createGenericSecretKey(byte[] secret) {
+            return new SecretKeySpec(secret, "Generic");
         }
 
         boolean paramsEquals(DHParameterSpec spec1, DHParameterSpec spec2) {


### PR DESCRIPTION
The 'Generic' algorithm was introduced in JDK 25 with [JDK-8189441](https://bugs.openjdk.org/browse/JDK-8189441).

In finite field DiffieHellman, the 'Generic' algorithm does not strip leading zero bytes (TlsPremasterSecret does that).
In elliptic curve DH, the algorithm is identical to 'TlsPremasterSecret'.

From JDK 27 the 'Generic' algorithm will be used in TLS 1.3 handshake.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [BRISBANE-5](https://bugs.openjdk.org/browse/BRISBANE-5): Support Generic algorithm in KeyAgreement.generateSecret(String) (**Bug** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/brisbane.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/6.diff">https://git.openjdk.org/brisbane/pull/6.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/6#issuecomment-4540469107)
</details>
