### PR TITLE
13: Remove export of com.oracle.jipher.provider

### DIFF
--- a/config/java.security/Pos1.java.security
+++ b/config/java.security/Pos1.java.security
@@ -1,6 +1,6 @@
 # This test config file is for testing provider registration scenario:
 
-security.provider.1=com.oracle.jipher.provider.JipherJCE
+security.provider.1=JipherJCE
 security.provider.2=SUN
 security.provider.3=SunRsaSign
 security.provider.4=SunEC

--- a/config/java.security/PosN.java.security
+++ b/config/java.security/PosN.java.security
@@ -12,5 +12,5 @@ security.provider.9=SunPCSC
 security.provider.10=JdkLDAP
 security.provider.11=JdkSASL
 security.provider.12=SunPKCS11
-security.provider.13=com.oracle.jipher.provider.JipherJCE
+security.provider.13=JipherJCE
 

--- a/src/intTest/java/com/oracle/test/integration/JipherJCEProviderTest.java
+++ b/src/intTest/java/com/oracle/test/integration/JipherJCEProviderTest.java
@@ -48,7 +48,7 @@ import java.security.Provider;
 
 import org.junit.Test;
 
-import com.oracle.jipher.provider.JipherJCE;
+import com.oracle.jiphertest.util.ProviderUtil;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -57,25 +57,20 @@ import static org.junit.Assert.assertNotNull;
 public class JipherJCEProviderTest {
 
     @Test
-    public void main() throws Exception {
-        JipherJCE.main(null);
-    }
-
-    @Test
     public void getInfo() throws Exception {
-        JipherJCE prov = new JipherJCE();
-        assertNotNull(prov.getInfo());
+        Provider provider = ProviderUtil.get();
+        assertNotNull(provider.getInfo());
     }
 
     @Test
     public void getVersion() throws Exception {
-        JipherJCE prov = new JipherJCE();
-        assertFalse(prov.getVersionStr().isEmpty());
+        Provider provider = ProviderUtil.get();
+        assertFalse(provider.getVersionStr().isEmpty());
     }
 
     @Test
     public void serializeDeserialize() throws Exception {
-        Provider provider = new JipherJCE();
+        Provider provider = ProviderUtil.get();
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);

--- a/src/intTest/java/com/oracle/test/integration/JipherModuleTest.java
+++ b/src/intTest/java/com/oracle/test/integration/JipherModuleTest.java
@@ -46,8 +46,6 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.oracle.jipher.provider.JipherJCE;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -60,7 +58,8 @@ public class JipherModuleTest {
         // This test is only valid if jipher is listed on the module path
         Assume.assumeNotNull(System.getProperty("jdk.module.path"));
         Assume.assumeTrue(System.getProperty("jdk.module.path").contains("jipher-jce"));
-        MODULE_DESCRIPTOR = JipherJCE.class.getModule().getDescriptor();
+        Module module = ModuleLayer.boot().findModule("com.oracle.jipher").orElseThrow();
+        MODULE_DESCRIPTOR = module.getDescriptor();
     }
 
     @Test

--- a/src/intTest/java/module-info.java
+++ b/src/intTest/java/module-info.java
@@ -39,8 +39,6 @@
  */
 
 open module com.oracle.jiphertest.integration {
-    requires com.oracle.jipher;
-
     requires com.oracle.jiphertest.other;
 
     requires org.junit.jupiter.api;

--- a/src/jipherTest/java/com/oracle/jiphertest/util/FipsProviderInfoUtil.java
+++ b/src/jipherTest/java/com/oracle/jiphertest/util/FipsProviderInfoUtil.java
@@ -40,8 +40,6 @@
 
 package com.oracle.jiphertest.util;
 
-import com.oracle.jipher.provider.JipherJCE;
-
 import static org.junit.Assert.assertEquals;
 
 public class FipsProviderInfoUtil {
@@ -57,9 +55,10 @@ public class FipsProviderInfoUtil {
     private static final boolean FIPS_186_4_TYPE_DOMAIN_PARAMETERS_SUPPORTED;
     private static final int     KDF_MIN_PWD_LEN;
 
+
     static {
         // Determine the OpenSSL FIPS provider name and version:
-        String jipherInfo = new JipherJCE().getInfo();
+        String jipherInfo = ProviderUtil.get().getInfo();
         String openSSLInfo = jipherInfo.substring(jipherInfo.indexOf('[') + 1, jipherInfo.indexOf(']'));
         String fipsProvider = openSSLInfo.split(" with ")[1];
         NAME = fipsProvider.split(" version ")[0];

--- a/src/jipherTest/java/com/oracle/jiphertest/util/ProviderUtil.java
+++ b/src/jipherTest/java/com/oracle/jiphertest/util/ProviderUtil.java
@@ -52,13 +52,12 @@ import java.security.SecureRandom;
 import java.security.Security;
 import java.security.Signature;
 import java.util.Arrays;
+import java.util.ServiceLoader;
 import javax.crypto.Cipher;
 import javax.crypto.KeyAgreement;
 import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKeyFactory;
-
-import com.oracle.jipher.provider.JipherJCE;
 
 /**
  * This class provides a single place to access a Provider to use for testing.
@@ -85,16 +84,26 @@ public class ProviderUtil {
             throw new Error("Testing property 'provider.test.mode' contained unrecognised value, "
                     + "expected one of " + Arrays.asList(ProvUsage.values()));
         }
+        Provider provider = getJipherInstanceViaServiceLoader();
         if (PROV_USAGE == ProvUsage.DYNAMIC_FIRST) {
-            Security.insertProviderAt(new JipherJCE(), 1);
+            Security.insertProviderAt(provider, 1);
         } else if (PROV_USAGE == ProvUsage.DYNAMIC_STRING) {
-            Security.addProvider(new JipherJCE());
+            Security.addProvider(provider);
         } else if (PROV_USAGE == ProvUsage.INSTANCE) {
             // Its important only to create the provider instance provider when test configuration
             // specifies because the provider tests try to test first usage of the provider by
             // the JCE framework.
-            instance = new JipherJCE();
+            instance = provider;
         }
+    }
+
+    static Provider getJipherInstanceViaServiceLoader() {
+        return ServiceLoader.load(Provider.class)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(provider -> provider.getName().equals("JipherJCE"))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("JipherJCE provider not found"));
     }
 
     public static Provider get() {

--- a/src/jipherTest/java/module-info.java
+++ b/src/jipherTest/java/module-info.java
@@ -44,15 +44,9 @@ module com.oracle.jiphertest.other {
     exports com.oracle.jiphertest.testdata;
     exports com.oracle.jiphertest.util;
 
-    // The com.oracle.jiphertest.util.ProviderUtil class creates an instance of com.oracle.jipher.provider.JipherJCE to
-    // dynamically register it as a java security provider.
-    // The com.oracle.jiphertest.util.FipsProviderInfoUtil class creates an instance of
-    // com.oracle.jipher.provider.JipherJCE from which it can query information about the OpenSSL FIPS provider version.
-    // The com.oracle.systest.classloader.CipherTest system test uses com.oracle.jiphertest.testdata to load test data,
-    // but it does NOT list jipher-jce on the classpath because it uses a URLClassLoader to load the jipher-jce JAR.
-    // Consequently, the following 'requires' statement is 'static' to indicate that the dependency is required
-    // at compile time but is optional at run time.
-    requires static com.oracle.jipher;
+    // The com.oracle.jiphertest.util.ProviderUtil class creates an instance of the JiperJCE provider via the
+    // service loader to dynamically register it as a java security provider.
+    uses java.security.Provider;
 
     // testdata uses gson
     requires com.google.gson;

--- a/src/jipherTest/resources/com/oracle/jiphertest/helpers/java.security/JIPHER_JSSE.java.security
+++ b/src/jipherTest/resources/com/oracle/jiphertest/helpers/java.security/JIPHER_JSSE.java.security
@@ -1,4 +1,4 @@
-security.provider.1=com.oracle.jipher.provider.JipherJCE
+security.provider.1=JipherJCE
 security.provider.2=SUN
 security.provider.3=SunRsaSign
 security.provider.4=SunEC

--- a/src/main/java/com/oracle/jipher/provider/JipherJCE.java
+++ b/src/main/java/com/oracle/jipher/provider/JipherJCE.java
@@ -209,8 +209,8 @@ public final class JipherJCE extends Provider {
      *         wrapped as the cause
      */
     private static String checkOpenSSLIsAvailableThenCallInfo() {
-        if (!isAvailable()) {
-            throw new ProviderException("OpenSSL is not available", loadingException());
+        if (!OpenSslValidator.isAvailable()) {
+            throw new ProviderException("OpenSSL is not available", OpenSslValidator.loadingException());
         }
         return info(true);
     }
@@ -284,24 +284,6 @@ public final class JipherJCE extends Provider {
         } catch (ParseException e) {
             return 0;
         }
-    }
-
-    /**
-     * Checks whether the underlying OpenSSL native library is available.
-     *
-     * @return {@code true} if OpenSSL can be loaded and used, {@code false} otherwise
-     */
-    public static boolean isAvailable() {
-        return OpenSslValidator.isAvailable();
-    }
-
-    /**
-     * Retrieves the exception that occurred while attempting to load OpenSSL.
-     *
-     * @return a {@link ProviderException} describing the failure, or {@code null} if no error occurred
-     */
-    public static ProviderException loadingException() {
-        return OpenSslValidator.loadingException();
     }
 
     /**

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -40,7 +40,5 @@
 
 module com.oracle.jipher {
     provides java.security.Provider with com.oracle.jipher.provider.JipherJCE;
-
-    exports com.oracle.jipher.provider;
 }
 

--- a/src/systemTest/java/com/oracle/systest/version/UnsanctionedCryptoLibraryVersionTest.java
+++ b/src/systemTest/java/com/oracle/systest/version/UnsanctionedCryptoLibraryVersionTest.java
@@ -40,14 +40,14 @@
 
 package com.oracle.systest.version;
 
+import java.security.Provider;
 import java.security.ProviderException;
+import java.util.ServiceLoader;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import com.oracle.jipher.provider.JipherJCE;
 
 public class UnsanctionedCryptoLibraryVersionTest {
 
@@ -62,23 +62,17 @@ public class UnsanctionedCryptoLibraryVersionTest {
     }
 
     @Test
-    public void isAvailable()  {
-        Assertions.assertFalse(JipherJCE.isAvailable());
-    }
-
-    @Test
-    public void loadingException()  {
-        Throwable t = JipherJCE.loadingException();
-        validateCause(t);
-    }
-
-    @Test
-    public void loadJipher()  {
+    public void loadJipher() {
         try {
-            new JipherJCE();
-            Assertions.fail("Should throw ProviderException");
-        } catch (ProviderException e) {
-            validateCause(e);
+            ServiceLoader.load(Provider.class)
+                    .stream()
+                    .map(ServiceLoader.Provider::get)
+                    .filter(provider -> provider.getName().equals("JipherJCE"))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("JipherJCE provider not found"));
+            Assertions.fail("Should throw ServiceConfigurationError caused by ProviderException");
+        } catch (Throwable t) {
+            validateCause(t);
         }
     }
 

--- a/src/systemTest/java/com/oracle/systest/version/UnsanctionedFipsProviderVersionTest.java
+++ b/src/systemTest/java/com/oracle/systest/version/UnsanctionedFipsProviderVersionTest.java
@@ -40,14 +40,14 @@
 
 package com.oracle.systest.version;
 
+import java.security.Provider;
 import java.security.ProviderException;
+import java.util.ServiceLoader;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import com.oracle.jipher.provider.JipherJCE;
 
 public class UnsanctionedFipsProviderVersionTest {
 
@@ -62,23 +62,17 @@ public class UnsanctionedFipsProviderVersionTest {
     }
 
     @Test
-    public void isAvailable()  {
-        Assertions.assertFalse(JipherJCE.isAvailable());
-    }
-
-    @Test
-    public void loadingException()  {
-        Throwable t = JipherJCE.loadingException();
-        validateCause(t);
-    }
-
-    @Test
-    public void loadJipher()  {
+    public void loadJipher() {
         try {
-            new JipherJCE();
-            Assertions.fail("Should throw ProviderException");
-        } catch (ProviderException e) {
-            validateCause(e);
+            ServiceLoader.load(Provider.class)
+                    .stream()
+                    .map(ServiceLoader.Provider::get)
+                    .filter(provider -> provider.getName().equals("JipherJCE"))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("JipherJCE provider not found"));
+            Assertions.fail("Should throw ServiceConfigurationError caused by ProviderException");
+        } catch (Throwable t) {
+            validateCause(t);
         }
     }
 

--- a/src/test/java/com/oracle/jipher/internal/openssl/OpenSsslValidatorTest.java
+++ b/src/test/java/com/oracle/jipher/internal/openssl/OpenSsslValidatorTest.java
@@ -1,0 +1,19 @@
+package com.oracle.jipher.internal.openssl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class OpenSsslValidatorTest {
+
+    @Test
+    public void isAvailable() {
+        assertTrue(OpenSslValidator.isAvailable());
+    }
+
+    @Test
+    public void loadingException() {
+        assertNull(OpenSslValidator.loadingException());
+    }
+}

--- a/src/test/java/com/oracle/jipher/provider/JipherJCETest.java
+++ b/src/test/java/com/oracle/jipher/provider/JipherJCETest.java
@@ -334,12 +334,6 @@ public class JipherJCETest {
     }
 
     @Test
-    public void isAvailable() {
-        assertTrue(JipherJCE.isAvailable());
-        assertNull(JipherJCE.loadingException());
-    }
-
-    @Test
     public void serviceAlgorithmRegistrationWithFipsProviderCapabilities()
     {
         for (int index = 0; index < (1 << 3); index++) {


### PR DESCRIPTION
Exporting com.oracle.jipher.provider means that all public methods/fields of the public classes in that package are an API and supported interface.

Currently com.oracle.jipher.provider is exported for two reasons:
1) To accommodate modular applications dynamically registering the JipherJCE provider without resorting to the ServiceLoader
2) To accommodate modular applications calling isAvailable and loadingException static methods on the com.oracle.jipher.provider.JipherJCE class

Neither (1) nor (2) are essential features of the library.

1) modular applications can dynamically register the JipherJCE provider using the ServiceLoader
2) the cause of failures that prevent statically or dynamically registering the JipherJCE provider using the ServiceLoader are detailed in the exception chain chained from the java.util.ServiceConfigurationError thrown by the ServiceLoader. Consequently the isAvailable and loadingException static methods are not necessary.

It would be good to limit the API to essential elements only.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [BRISBANE-13](https://bugs.openjdk.org/browse/BRISBANE-13): Remove export of com.oracle.jipher.provider (**Enhancement** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/brisbane.git pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/7.diff">https://git.openjdk.org/brisbane/pull/7.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/7#issuecomment-4541454798)
</details>
