### PR TITLE
12: Use min supported key len when calling EVP_MAC_init to clear sensitive data

### DIFF
--- a/src/main/java/com/oracle/jipher/internal/openssl/ffm/EvpMacCtx.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/ffm/EvpMacCtx.java
@@ -76,6 +76,8 @@ import static java.lang.Math.toIntExact;
 
 final class EvpMacCtx extends PoolableObjectBase<EvpMacCtx> implements EVP_MAC_CTX {
 
+    static final int FIPS_MIN_SECURITY_STRENGTH_BITS = 112;
+
     static final ObjectPool<EvpMacCtx> HMAC_MAC_CTX_OBJECT_POOL = new ObjectPool<>();
 
     /*
@@ -193,7 +195,7 @@ final class EvpMacCtx extends PoolableObjectBase<EvpMacCtx> implements EVP_MAC_C
         if (this.initialized) {
             // Init with an arbitrary key of minimum allowed strength.
             try {
-                this.init(new byte[112 * 8], OsslParamBufferImpl.EMPTY_PARAM_BUFFER);
+                this.init(new byte[FIPS_MIN_SECURITY_STRENGTH_BITS / 8], OsslParamBufferImpl.EMPTY_PARAM_BUFFER);
             } catch (Exception e) {
                 // Init failed. Don't release this EvpMacCtx to the hmac pool.
                 return;
@@ -275,17 +277,22 @@ final class EvpMacCtx extends PoolableObjectBase<EvpMacCtx> implements EVP_MAC_C
     public void init(byte[] key, OsslParamBuffer paramBuffer) {
         try (Arena arena = Arena.ofConfined()) {
             SegmentAllocator allocator = key == null || key.length <= BUFFER_SIZE ? this.keyBufPA : arena;
-            MemorySegment keySeg = FfmOpenSsl.allocateFromNullable(key, allocator);
             long keyLen = key != null ? key.length : 0L;
             this.initialized = false;
-            withDataParamsSeg(paramBuffer, (paramsSeg) -> {
-                try {
-                    EVP_MAC_INIT_FUNC.invokeExact(this.evpMacCtx, keySeg, keyLen, paramsSeg);
-                } catch (Throwable t) {
-                    throw mapException(t);
-                }
-            });
-            this.initialized = true;
+            MemorySegment keySeg = FfmOpenSsl.allocateFromNullable(key, allocator);
+            try {
+                withDataParamsSeg(paramBuffer, (paramsSeg) -> {
+                    try {
+                        EVP_MAC_INIT_FUNC.invokeExact(this.evpMacCtx, keySeg, keyLen, paramsSeg);
+                    } catch (Throwable t) {
+                        throw mapException(t);
+                    }
+                });
+                this.initialized = true;
+            } finally {
+                // Clear the off-heap copy of the key data.
+                keySeg.fill((byte)0);
+            }
         }
     }
 


### PR DESCRIPTION
Use appropriate EvpMacCtx release dummy key size.

Also clear the temporary FFM key segment


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [BRISBANE-12](https://bugs.openjdk.org/browse/BRISBANE-12): Use min supported key len when calling EVP_MAC_init to clear sensitive data (**Bug** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/brisbane.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/8.diff">https://git.openjdk.org/brisbane/pull/8.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/8#issuecomment-4570532454)
</details>
