### PR TITLE
14: Make expected OpenSSL version build metadata string configurable.

### DIFF
--- a/src/test/java/com/oracle/jipher/internal/openssl/OpenSslTest.java
+++ b/src/test/java/com/oracle/jipher/internal/openssl/OpenSslTest.java
@@ -106,8 +106,14 @@ public class OpenSslTest {
 
     @Test
     public void versionBuildMetadataString() {
-        // OPENSSL_version_build_metadata() will return an empty string unless OpenSSL is built with a different build metadata string.
-        assertEquals("", openSsl.versionBuildMetadataString());
+        // OPENSSL_version_build_metadata() will return an empty string unless OpenSSL
+        // was built with custom version build metadata. Because the value depends on the
+        // build configuration, only verify it when an expected value is provided.
+        String actual = openSsl.versionBuildMetadataString();
+        String expected = System.getProperty("jipher.test.openssl.versionBuildMetadataString");
+        if (expected != null) {
+            assertEquals(expected, actual);
+        }
     }
 
     @Test


### PR DESCRIPTION
At present the OpenSSL interface tests expect the version build metadata string reported by the OpenSSL cryptography library to be the empty string. 

This is the default value reported by a build of the OpenSSL. 

However a custom build of OpenSSL may set a non-empty string. The test therefore should not assume that it will be the empty string and instead only check for a string if supplied.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `14: Make expected OpenSSL version build metadata string configurable.`

### Issue
 * [BRISBANE-14](https://bugs.openjdk.org/browse/BRISBANE-14): Make expected OpenSSL version build metadata string configurable. (**Bug** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.org/brisbane.git pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/9.diff">https://git.openjdk.org/brisbane/pull/9.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/9#issuecomment-4570793335)
</details>
