### PR TITLE
29: Use RAND_priv_bytes_ex to generate secret keys

### DIFF
--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -96,7 +96,7 @@ jacocoTestCoverageVerification {
 
     mustRunAfter jacocoTestReport
     violationRules {
-        failOnViolation project.hasProperty('enforceCoverage') && project.property('enforceCoverage').toBoolean()
+        failOnViolation = project.findProperty('enforceCoverage')?.toString()?.toBoolean() ?: false
         rule {
             element = 'PACKAGE'
             includes = ['com.oracle.*']

--- a/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
@@ -78,8 +78,4 @@ public final class Rand {
     public static void generatePrivate(byte[] bytes) throws ProviderException {
         LibCtx.randPrivBytes(bytes, STRENGTH);
     }
-
-    public void nextBytes(byte[] bytes) {
-        generate(bytes);
-    }
 }

--- a/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
@@ -49,7 +49,7 @@ public final class Rand {
 
     // Prevent instantiation
     private Rand() {}
-    
+
     public static byte[] generate(int numBytes) {
         byte[] bytes = new byte[numBytes];
         generate(bytes);

--- a/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
@@ -40,8 +40,6 @@
 
 package com.oracle.jipher.internal.openssl;
 
-import java.security.ProviderException;
-
 /**
  * Random byte generator.
  */
@@ -49,13 +47,13 @@ public final class Rand {
 
     static private final int STRENGTH = 256;
 
-    public static byte[] generate(int numBytes) throws ProviderException {
+    public static byte[] generate(int numBytes) {
         byte[] bytes = new byte[numBytes];
         generate(bytes);
         return bytes;
     }
 
-    public static byte[] generatePrivate(int numBytes) throws ProviderException {
+    public static byte[] generatePrivate(int numBytes) {
         byte[] bytes = new byte[numBytes];
         generatePrivate(bytes);
         return bytes;
@@ -64,18 +62,16 @@ public final class Rand {
     /**
      * Generate random bytes.
      * @param bytes the byte array to fill with random bytes
-     * @throws ProviderException if the bytes could not be generated
      */
-    public static void generate(byte[] bytes) throws ProviderException {
+    public static void generate(byte[] bytes) {
         LibCtx.randBytes(bytes, STRENGTH);
     }
 
     /**
      * Generate random bytes. Use the random designated for long-lived secrets.
      * @param bytes the byte array to fill with random bytes
-     * @throws ProviderException if the bytes could not be generated
      */
-    public static void generatePrivate(byte[] bytes) throws ProviderException {
+    public static void generatePrivate(byte[] bytes) {
         LibCtx.randPrivBytes(bytes, STRENGTH);
     }
 }

--- a/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
@@ -47,6 +47,9 @@ public final class Rand {
 
     static private final int STRENGTH = 256;
 
+    // Prevent instantiation
+    private Rand() {}
+    
     public static byte[] generate(int numBytes) {
         byte[] bytes = new byte[numBytes];
         generate(bytes);

--- a/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/Rand.java
@@ -55,6 +55,12 @@ public final class Rand {
         return bytes;
     }
 
+    public static byte[] generatePrivate(int numBytes) throws ProviderException {
+        byte[] bytes = new byte[numBytes];
+        generatePrivate(bytes);
+        return bytes;
+    }
+
     /**
      * Generate random bytes.
      * @param bytes the byte array to fill with random bytes
@@ -62,6 +68,15 @@ public final class Rand {
      */
     public static void generate(byte[] bytes) throws ProviderException {
         LibCtx.randBytes(bytes, STRENGTH);
+    }
+
+    /**
+     * Generate random bytes. Use the random designated for long-lived secrets.
+     * @param bytes the byte array to fill with random bytes
+     * @throws ProviderException if the bytes could not be generated
+     */
+    public static void generatePrivate(byte[] bytes) throws ProviderException {
+        LibCtx.randPrivBytes(bytes, STRENGTH);
     }
 
     public void nextBytes(byte[] bytes) {

--- a/src/main/java/com/oracle/jipher/internal/spi/AesKeyGenerator.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/AesKeyGenerator.java
@@ -117,7 +117,7 @@ public class AesKeyGenerator extends KeyGeneratorSpi {
      */
     @Override
     protected SecretKey engineGenerateKey() {
-        byte[] bytes = Rand.generate(this.keySize);
+        byte[] bytes = Rand.generatePrivate(this.keySize);
         try {
             return new SecretKeySpec(bytes, "AES");
         } finally {

--- a/src/main/java/com/oracle/jipher/internal/spi/Drbg.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/Drbg.java
@@ -52,11 +52,6 @@ public final class Drbg extends SecureRandomSpi {
     @Serial
     private static final long serialVersionUID = 5952625728129925027L;
 
-    private final transient Rand rand;
-    public Drbg() {
-        this.rand = new Rand();
-    }
-
     @Override
     protected void engineSetSeed(byte[] seed) {
         // Do nothing
@@ -68,7 +63,7 @@ public final class Drbg extends SecureRandomSpi {
             throw new IllegalArgumentException("numBytes cannot be negative");
         }
         byte[] bytes = new byte[numBytes];
-        rand.nextBytes(bytes);
+        Rand.generate(bytes);
         return bytes;
     }
 
@@ -77,14 +72,6 @@ public final class Drbg extends SecureRandomSpi {
         if (bytes == null) {
             throw new NullPointerException("bytes cannot be null");
         }
-        this.rand.nextBytes(bytes);
-    }
-
-    /*
-     * Return a new instance of Drbg on deserialization.
-     */
-    @Serial
-    private Object readResolve() {
-        return new Drbg();
+        Rand.generate(bytes);
     }
 }

--- a/src/main/java/com/oracle/jipher/internal/spi/Drbg.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/Drbg.java
@@ -62,9 +62,7 @@ public final class Drbg extends SecureRandomSpi {
         if (numBytes < 0) {
             throw new IllegalArgumentException("numBytes cannot be negative");
         }
-        byte[] bytes = new byte[numBytes];
-        Rand.generate(bytes);
-        return bytes;
+        return Rand.generate(numBytes);
     }
 
     @Override

--- a/src/main/java/com/oracle/jipher/internal/spi/HmacKeyGenerator.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/HmacKeyGenerator.java
@@ -86,7 +86,7 @@ public abstract class HmacKeyGenerator extends KeyGeneratorSpi {
 
     @Override
     protected SecretKey engineGenerateKey() {
-        byte[] bytes = Rand.generate(this.keyByteLen == -1 ? this.defaultKeyLenBytes : this.keyByteLen);
+        byte[] bytes = Rand.generatePrivate(this.keyByteLen == -1 ? this.defaultKeyLenBytes : this.keyByteLen);
         try {
             return new SecretKeySpec(bytes, this.algName);
         } finally {

--- a/src/main/java/com/oracle/jipher/internal/spi/TlsRsaPremasterSecretGenerator.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/TlsRsaPremasterSecretGenerator.java
@@ -106,7 +106,7 @@ public final class TlsRsaPremasterSecretGenerator extends KeyGeneratorSpi {
         byte[] premaster = this.paramSpec.getEncodedSecret();
         try {
             if (premaster == null) {
-                premaster = Rand.generate(PREMASTER_SECRET_KEY_LEN);
+                premaster = Rand.generatePrivate(PREMASTER_SECRET_KEY_LEN);
             }
             premaster[0] = (byte) this.paramSpec.getMajorVersion();
             premaster[1] = (byte) this.paramSpec.getMinorVersion();


### PR DESCRIPTION
Ensure that keys and other secret material are generated using the OpenSSL 'private' random.

This means calling LibCtx.randPrivBytes() where generation happens within Jipher and not inside OpenSSL.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [BRISBANE-29](https://bugs.openjdk.org/browse/BRISBANE-29): Use RAND_priv_bytes_ex to generate secret keys (**Sub-task** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**) ⚠️ Review applies to [a15fbf28](https://git.openjdk.org/brisbane/pull/12/files/a15fbf28001ac50e9c0ad1a01f2e4b8bcf4eb630)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/brisbane.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/12.diff">https://git.openjdk.org/brisbane/pull/12.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/12#issuecomment-4900354575)
</details>
