### PR TITLE
32: Consistently Throw SignatureException when directed to verify a 0 length signature

### DIFF
--- a/src/intTest/java/com/oracle/test/integration/signature/SignatureTest.java
+++ b/src/intTest/java/com/oracle/test/integration/signature/SignatureTest.java
@@ -59,7 +59,6 @@ import java.util.Collection;
 
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -434,7 +433,6 @@ public abstract class SignatureTest {
         sig.verify(bb);
     }
 
-    @Ignore
     @Test (expected = SignatureException.class)
     public void verifyExceptionSigZeroLength() throws Exception {
         initVerify();

--- a/src/main/java/com/oracle/jipher/internal/spi/DigestSignature.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/DigestSignature.java
@@ -193,6 +193,9 @@ abstract class DigestSignature extends SignatureSpi {
         initIfRequired();
         // Rely on Signature to check that object initialized for verify.
         try {
+            if (len == 0) {
+                throw new SignatureException("Signature must not be zero length");
+            }
             return this.ctx.verifyFinal(sigBytes, offset, len);
         } finally {
             releaseCtx();

--- a/src/main/java/com/oracle/jipher/internal/spi/NoDigestSig.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/NoDigestSig.java
@@ -158,6 +158,9 @@ public abstract class NoDigestSig extends SignatureSpi {
         initIfRequired();
         // Rely on Signature to check that object initialized for verify.
         try (OsslArena confinedArena = OsslArena.ofConfined()) {
+            if (len == 0) {
+                throw new SignatureException("Signature must not be zero length");
+            }
             PkeyCtx.Signature ctx = new PkeyCtx.Signature(this.lastPkey, confinedArena);
             byte[] bb = this.tbs.toByteArray();
             verifyInit(ctx);


### PR DESCRIPTION
Check for zero-length signatures before calling into OpenSSL verification and throw `SignatureException` 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [BRISBANE-32](https://bugs.openjdk.org/browse/BRISBANE-32): Consistently Throw SignatureException when directed to verify a 0 length signature (**Bug** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/brisbane.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/14.diff">https://git.openjdk.org/brisbane/pull/14.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/14#issuecomment-4971376903)
</details>
