### PR TITLE
21: Support testing with fips-provider-next

### DIFF
--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -41,7 +41,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = '0.8.14' // Officially supports Java 25 (class file major version 69)
+    toolVersion = '0.8.15' // Officially supports Java 25 (class file major version 69)
 }
 
 jacocoTestCoverageVerification {
@@ -60,10 +60,10 @@ jacocoTestCoverageVerification {
                                 'com/oracle/jipher/internal/openssl/LibCtx.class'] as Set
         boolean usingOsInstance = project.findProperty('jipher.openssl.useOsInstance')?.toString()?.toBoolean()
         if (usingOsInstance) {
-                    // Exclude classes from coverage verification that are fully or partially skipped when testing
-                    // the OS provided Oracle Linux 9+ FIPS module or due to an absence of support for:
-                    //   * DESEDE or DSA keys.
-                    //   * FIPS 186-4 type domain parameters (which impacts DH key testing)
+            // Exclude classes from coverage verification that are fully or partially skipped when testing
+            // the OS provided Oracle Linux 9+ FIPS module or due to an absence of support for:
+            //   * DESEDE or DSA keys.
+            //   * FIPS 186-4 type domain parameters (which impacts DH key testing)
             classesToExclude.addAll(['com/oracle/jipher/internal/key/JceDsaPublicKey.class',
                             'com/oracle/jipher/internal/spi/*DesEde*.class',
                             'com/oracle/jipher/internal/spi/*DESede*.class',
@@ -77,7 +77,7 @@ jacocoTestCoverageVerification {
             }
             int exitValue = fipsVersionDetector.result.get().exitValue
             if (exitValue != 0) {
-            // fips-provider-next not installed. Module-Lattice (ML) support missing.
+                //fips-provider-next not installed. Module-Lattice (ML) support missing.
                 classesToExclude.addAll(['com/oracle/jipher/internal/common/MlUtil.class',
                             'com/oracle/jipher/internal/key/JceMl*.class',
                             'com/oracle/jipher/internal/spi/*Kem*.class',

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -51,47 +51,44 @@ jacocoTestCoverageVerification {
     }
 
     afterEvaluate {
-        if (project.findProperty('jipher.openssl.useOsInstance')?.toString()?.toBoolean()) {
-            getClassDirectories().setFrom(classDirectories.files.collect {
-                fileTree(it) {
+        def classesToExclude = [// derEncode of DHFIPSParameterSpec is not tested
+                                'com/oracle/jipher/internal/key/JceDhPublicKey.class',
+                                'com/oracle/jipher/internal/key/JceDhPrivateKey.class',
+                                // DhKeyFactory dhX509DomainParametersDecode is not tested
+                                'com/oracle/jipher/internal/spi/DhKeyFactory.class',
+                                // LibCtx is tested by system tests
+                                'com/oracle/jipher/internal/openssl/LibCtx.class'] as Set
+        boolean usingOsInstance = project.findProperty('jipher.openssl.useOsInstance')?.toString()?.toBoolean()
+        if (usingOsInstance) {
                     // Exclude classes from coverage verification that are fully or partially skipped when testing
                     // the OS provided Oracle Linux 9+ FIPS module or due to an absence of support for:
                     //   * DESEDE or DSA keys.
                     //   * FIPS 186-4 type domain parameters (which impacts DH key testing)
-                    //   * Module-Lattice (ML) support
-                    exclude(
-                            'com/oracle/jipher/internal/key/JceDhPublicKey.class',
-                            'com/oracle/jipher/internal/key/JceDhPrivateKey.class',
-                            'com/oracle/jipher/internal/key/JceDsaPublicKey.class',
+            classesToExclude.addAll(['com/oracle/jipher/internal/key/JceDsaPublicKey.class',
                             'com/oracle/jipher/internal/spi/*DesEde*.class',
                             'com/oracle/jipher/internal/spi/*DESede*.class',
-                            'com/oracle/jipher/internal/spi/DhKeyFactory.class',
                             'com/oracle/jipher/internal/spi/DsaKeyFactory.class',
-                            'com/oracle/jipher/internal/openssl/LibCtx.class',
                             'com/oracle/jipher/internal/openssl/Pkey.class',
-                            'com/oracle/jipher/internal/common/MlUtil.class',
+                            'com/oracle/jipher/provider/*.class'])
+            def fipsVersionDetector = providers.exec {
+                commandLine 'rpm', '-q', 'fips-provider-next'
+                // Dont fail the gradle script if exit value is non zero.
+                ignoreExitValue = true
+            }
+            int exitValue = fipsVersionDetector.result.get().exitValue
+            if (exitValue != 0) {
+            // fips-provider-next not installed. Module-Lattice (ML) support missing.
+                classesToExclude.addAll(['com/oracle/jipher/internal/common/MlUtil.class',
                             'com/oracle/jipher/internal/key/JceMl*.class',
                             'com/oracle/jipher/internal/spi/*Kem*.class',
-                            'com/oracle/jipher/internal/spi/*Ml*.class',
-                            'com/oracle/jipher/provider/*.class'
-                    )
-                }
-            })
-        } else {
-            getClassDirectories().setFrom(classDirectories.files.collect {
-                fileTree(it) {
-                    exclude(
-                            // derEncode of DHFIPSParameterSpec is not tested
-                            'com/oracle/jipher/internal/key/JceDhPublicKey.class',
-                            'com/oracle/jipher/internal/key/JceDhPrivateKey.class',
-                            // DhKeyFactory dhX509DomainParametersDecode is not tested
-                            'com/oracle/jipher/internal/spi/DhKeyFactory.class',
-                            // LibCtx is tested by system tests
-                            'com/oracle/jipher/internal/openssl/LibCtx.class'
-                    )
-                }
-            })
+                            'com/oracle/jipher/internal/spi/*Ml*.class'])
+            }
         }
+        classDirectories.setFrom(classDirectories.files.collect {
+            fileTree(it) {
+                exclude(classesToExclude)
+            }
+        })
     }
 
     mustRunAfter jacocoTestReport

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -41,7 +41,9 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = '0.8.15' // Officially supports Java 25 (class file major version 69)
+    // Officially supports Java 26 (class file major version 70),
+    // Experimental support for Java 27 class files
+    toolVersion = '0.8.15'
 }
 
 jacocoTestCoverageVerification {

--- a/src/jipherTest/java/com/oracle/jiphertest/util/FipsProviderInfoUtil.java
+++ b/src/jipherTest/java/com/oracle/jiphertest/util/FipsProviderInfoUtil.java
@@ -40,7 +40,7 @@
 
 package com.oracle.jiphertest.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class FipsProviderInfoUtil {
     private static final String NAME;
@@ -71,28 +71,26 @@ public class FipsProviderInfoUtil {
         MAJOR_VERSION = Integer.parseInt(patchVersionParts[0]);
         MINOR_VERSION = patchVersionParts.length > 1 ? Integer.parseInt(patchVersionParts[1]) : 0;
         PATCH_VERSION = patchVersionParts.length > 2 ?Integer.parseInt(patchVersionParts[2]) : 0;
-
+        boolean isPQCSupported;
         if (MAJOR_VERSION >=3 && MINOR_VERSION >=5) {
-            ML_KEM_IS_SUPPORTED = true;
-            ML_DSA_IS_SUPPORTED = true;
+            isPQCSupported = true;
         } else {
-            ML_KEM_IS_SUPPORTED = false;
-            ML_DSA_IS_SUPPORTED = false;
+            isPQCSupported = false;
         }
 
         // Note: The OpenSSL FIPS provider used on version 9 of these Linux distributions is also used on version 10.
         boolean isRHDerivative = NAME.contains("Red Hat Enterprise Linux") || NAME.contains("Oracle Linux");
 
         if (isRHDerivative) {
-            // These capabilities apply to version 3.0.7 of the FIPS provider distributed with these Linux distributions.
+            // These capabilities apply to versions 3.0.7 and 1.2.0 of the FIPS provider distributed with these Linux distributions.
             // This class will need to be updated to support any future version.
-            assertEquals("3.0.7", patchVersion);
-
+            assertTrue("3.0.7".equals(patchVersion) || "1.2.0".equals(patchVersion));
             DESEDE_IS_SUPPORTED = false;
             DSA_IS_SUPPORTED = false;
             SHA1_DIGEST_SIGNATURES_ARE_SUPPORTED = false;
             FIPS_186_4_TYPE_DOMAIN_PARAMETERS_SUPPORTED = false;
             KDF_MIN_PWD_LEN = 8;
+            isPQCSupported |= MAJOR_VERSION == 1;
         } else {
             DESEDE_IS_SUPPORTED = true;
             DSA_IS_SUPPORTED = true;
@@ -100,6 +98,7 @@ public class FipsProviderInfoUtil {
             FIPS_186_4_TYPE_DOMAIN_PARAMETERS_SUPPORTED = true;
             KDF_MIN_PWD_LEN = 0;
         }
+        ML_KEM_IS_SUPPORTED = ML_DSA_IS_SUPPORTED = isPQCSupported;
     }
 
     public static String getName() {

--- a/src/main/java/com/oracle/jipher/internal/spi/Capabilities.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/Capabilities.java
@@ -76,8 +76,8 @@ public class Capabilities {
             String[] versionComponents = patchVersion.split("-")[0].split("\\.");
             if (versionComponents.length >= 2) {
                 try {
-                    majorVersion = Integer.valueOf(versionComponents[0]);
-                    minorVersion = Integer.valueOf(versionComponents[1]);
+                    majorVersion = Integer.parseInt(versionComponents[0]);
+                    minorVersion = Integer.parseInt(versionComponents[1]);
                     DEBUG.println("FIPS Provider major version " + majorVersion);
                     DEBUG.println("FIPS Provider minor version " + minorVersion);
                     // FIPS certified support for PQC requires minor version >=5.

--- a/src/main/java/com/oracle/jipher/internal/spi/Capabilities.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/Capabilities.java
@@ -69,25 +69,24 @@ public class Capabilities {
         DEBUG.println("FIPS Provider detected " + name);
         DEBUG.println("FIPS Provider version " + patchVersion);
 
+        int majorVersion = -1;
+        int minorVersion = -1;
         boolean isPQCSupported = false;
         if (patchVersion != null) {
             String[] versionComponents = patchVersion.split("-")[0].split("\\.");
             if (versionComponents.length >= 2) {
                 try {
-                    int major = Integer.valueOf(versionComponents[0]);
-                    int minor = Integer.valueOf(versionComponents[1]);
-                    DEBUG.println("FIPS Provider major version " + major);
-                    DEBUG.println("FIPS Provider minor version " + minor);
+                    majorVersion = Integer.valueOf(versionComponents[0]);
+                    minorVersion = Integer.valueOf(versionComponents[1]);
+                    DEBUG.println("FIPS Provider major version " + majorVersion);
+                    DEBUG.println("FIPS Provider minor version " + minorVersion);
                     // FIPS certified support for PQC requires minor version >=5.
-                    isPQCSupported = (major == 3 && minor >= 5);
+                    isPQCSupported = (majorVersion == 3 && minorVersion >= 5);
                 } catch (NumberFormatException e) {
                     // Ignore
                 }
             }
         }
-        ML_KEM_IS_SUPPORTED = isPQCSupported;
-        ML_DSA_IS_SUPPORTED = isPQCSupported;
-
         boolean isRHDerivative = (name != null) &&
                 (name.contains("Red Hat Enterprise Linux") || name.contains("Oracle Linux"));
 
@@ -105,11 +104,15 @@ public class Capabilities {
             DESEDE_IS_SUPPORTED = false;
             DSA_IS_SUPPORTED = false;
             SHA1_DIGEST_SIGNATURES_ARE_SUPPORTED = false;
+            // In case of OS supplied OpenSSL, versions 1.x based of Kryoptic support PQC.
+            isPQCSupported |= majorVersion == 1;
         } else {
             DESEDE_IS_SUPPORTED = true;
             DSA_IS_SUPPORTED = true;
             SHA1_DIGEST_SIGNATURES_ARE_SUPPORTED = true;
         }
+        ML_KEM_IS_SUPPORTED = isPQCSupported;
+        ML_DSA_IS_SUPPORTED = isPQCSupported;
     }
 
     // The following getters facilitate mocking.

--- a/src/systemTest/java/com/oracle/systest/fips/FipsHkdfTest.java
+++ b/src/systemTest/java/com/oracle/systest/fips/FipsHkdfTest.java
@@ -71,7 +71,8 @@ public class FipsHkdfTest {
     // Enforcement of KDF minimum security strength was first added to OpenSSL in version 3.4.0
     static final boolean OPENSSL_ENFORCES_MIN_SECURITY_STRENGTH =
             (FipsProviderInfoUtil.getMajorVersion() > 3) ||
-            (FipsProviderInfoUtil.getMajorVersion() == 3 && FipsProviderInfoUtil.getMinorVersion() >= 4);
+            (FipsProviderInfoUtil.getMajorVersion() == 3 && FipsProviderInfoUtil.getMinorVersion() >= 4) ||
+            (FipsProviderInfoUtil.getMajorVersion() == 1 && FipsProviderInfoUtil.getMinorVersion() == 2);
 
     private final AlgorithmParameterSpec spec;
     private final OperationResult expected;

--- a/src/test/java/com/oracle/jipher/internal/openssl/EvpKdfTest.java
+++ b/src/test/java/com/oracle/jipher/internal/openssl/EvpKdfTest.java
@@ -356,12 +356,13 @@ public class EvpKdfTest extends EvpTest {
         OSSL_PARAM iterParam = OSSL_PARAM.ofUnsigned(EVP_KDF.KDF_PARAM_ITER, MIN_ITERATION_COUNT);
         OSSL_PARAM dgstParam = OSSL_PARAM.of(EVP_KDF.KDF_PARAM_DIGEST, MD_ALG);
         OSSL_PARAM passParam = OSSL_PARAM.of(EVP_KDF.KDF_PARAM_PASSWORD, password);
-
+        String fipsProviderName = FipsProviderInfoUtil.getName();
+        String fipsProviderVersion = FipsProviderInfoUtil.getVersionString();
         try {
             kdfCtx.derive(output, saltParam, iterParam, dgstParam, passParam);
-            Assert.assertFalse(FipsProviderInfoUtil.getName().contains("Linux 9"));
+            Assert.assertFalse(fipsProviderName.contains("Linux 9"));
         } catch (OpenSslException e) {
-            Assert.assertTrue(FipsProviderInfoUtil.getName().contains("Linux 9"));
+            Assert.assertTrue(fipsProviderVersion.startsWith("3.0.7") || fipsProviderVersion.equals("1.2.0"));
             Assert.assertTrue(e.getMessage().contains("invalid key length")); // (RHE/O)L error message uses 'key' not 'password'
         }
     }

--- a/src/test/java/com/oracle/jipher/internal/openssl/EvpPkeyTest.java
+++ b/src/test/java/com/oracle/jipher/internal/openssl/EvpPkeyTest.java
@@ -201,6 +201,13 @@ public class EvpPkeyTest extends EvpTest {
         dupCtx.isA(this.alg);
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void active() {
+        EVP_PKEY dupKey = key.dup();
+        dupKey.free();
+        dupKey.isA(alg);
+    }
+
     @Test
     public void upRef() throws Exception {
         try (OsslArena confinedArena = OsslArena.ofConfined()) {

--- a/src/test/java/com/oracle/jipher/internal/openssl/FipsProviderInfoUtil.java
+++ b/src/test/java/com/oracle/jipher/internal/openssl/FipsProviderInfoUtil.java
@@ -66,8 +66,8 @@ public class FipsProviderInfoUtil {
         boolean isPQCSupported = false;
         if (versionComponents.length >= 2) {
             try {
-                majorVersion = Integer.valueOf(versionComponents[0]);
-                minorVersion = Integer.valueOf(versionComponents[1]);
+                majorVersion = Integer.parseInt(versionComponents[0]);
+                minorVersion = Integer.parseInt(versionComponents[1]);
                 // FIPS certified support for PQC requires minor version >=5.
                 isPQCSupported = (majorVersion == 3 && minorVersion >= 5);
             } catch (NumberFormatException e) {

--- a/src/test/java/com/oracle/jipher/internal/openssl/FipsProviderInfoUtil.java
+++ b/src/test/java/com/oracle/jipher/internal/openssl/FipsProviderInfoUtil.java
@@ -40,7 +40,7 @@
 
 package com.oracle.jipher.internal.openssl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class FipsProviderInfoUtil {
     private static final String NAME;
@@ -61,34 +61,33 @@ public class FipsProviderInfoUtil {
         // Drop build number from version string
         String patchVersion = VERSION.split("-")[0];
         String[] versionComponents = patchVersion.split("\\.");
+        int majorVersion = -1;
+        int minorVersion = -1;
         boolean isPQCSupported = false;
         if (versionComponents.length >= 2) {
             try {
-                int major = Integer.valueOf(versionComponents[0]);
-                int minor = Integer.valueOf(versionComponents[1]);
+                majorVersion = Integer.valueOf(versionComponents[0]);
+                minorVersion = Integer.valueOf(versionComponents[1]);
                 // FIPS certified support for PQC requires minor version >=5.
-                isPQCSupported = (major == 3 && minor >= 5);
+                isPQCSupported = (majorVersion == 3 && minorVersion >= 5);
             } catch (NumberFormatException e) {
                 isPQCSupported = false;
             }
         }
-        ML_KEM_IS_SUPPORTED = isPQCSupported;
-        ML_DSA_IS_SUPPORTED = isPQCSupported;
-
-
         // Note: The OpenSSL FIPS provider used on version 9 of these Linux distributions is also used on version 10.
         boolean isRHDerivative = NAME.contains("Red Hat Enterprise Linux") || NAME.contains("Oracle Linux");
 
         if (isRHDerivative) {
-            // These capabilities apply to version 3.0.7 of the FIPS provider distributed with these Linux distributions.
+            // These capabilities apply to versions 3.0.7 and 1.2.0 of the FIPS provider distributed with these Linux distributions.
             // This class will need to be updated to support any future version.
-            assertEquals("3.0.7", patchVersion);
+            assertTrue("3.0.7".equals(patchVersion) || "1.2.0".equals(patchVersion));
 
             DESEDE_IS_SUPPORTED = false;
             DSA_IS_SUPPORTED = false;
             SHA1_DIGEST_SIGNATURES_ARE_SUPPORTED = false;
             FIPS_186_4_TYPE_DOMAIN_PARAMETERS_SUPPORTED = false;
             KDF_MIN_PWD_LENGTH = 8;
+            isPQCSupported |= majorVersion == 1;
         } else {
             DESEDE_IS_SUPPORTED = true;
             DSA_IS_SUPPORTED = true;
@@ -96,6 +95,8 @@ public class FipsProviderInfoUtil {
             FIPS_186_4_TYPE_DOMAIN_PARAMETERS_SUPPORTED = true;
             KDF_MIN_PWD_LENGTH = 0;
         }
+        ML_KEM_IS_SUPPORTED = isPQCSupported;
+        ML_DSA_IS_SUPPORTED = isPQCSupported;
     }
 
     public static String getName() {

--- a/src/test/java/com/oracle/jipher/internal/openssl/LibCtxTest.java
+++ b/src/test/java/com/oracle/jipher/internal/openssl/LibCtxTest.java
@@ -55,7 +55,7 @@ public class LibCtxTest {
     @Test
     public void getFipsProviderVersionString() throws Exception {
         String version = LibCtx.getFipsProviderVersionString();
-        assertTrue(version.startsWith("3."));
+        assertTrue(version.startsWith("3.") || version.equals("1.2.0"));
     }
 
     @Test


### PR DESCRIPTION
Support for Oracle Linux FIPS Provider version 1.2.0 (fips-provider-next) when Jipher is used with OS Instance OpenSSL.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [BRISBANE-21](https://bugs.openjdk.org/browse/BRISBANE-21): Support testing with fips-provider-next (**Enhancement** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/brisbane.git pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/15.diff">https://git.openjdk.org/brisbane/pull/15.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/15#issuecomment-4991222192)
</details>
