### PR TITLE
54: Ensure OSSL_PARAM dataSize is valid for store operations

### DIFF
--- a/src/main/java/com/oracle/jipher/internal/openssl/OSSL_PARAM.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/OSSL_PARAM.java
@@ -96,14 +96,24 @@ public final class OSSL_PARAM implements Destroyable {
         this(key, dataType, data, data.length, PARAM_UNMODIFIED, false);
     }
 
-    // Intended to be invoked by decoders.
-    public OSSL_PARAM(String key, Type dataType, byte[] data, long dataSize, long returnSize, boolean sensitive) {
+    OSSL_PARAM(String key, Type dataType, byte[] data, long dataSize, long returnSize, boolean sensitive) {
+        if (dataSize < 0L) {
+            throw new IllegalArgumentException("dataSize must be >= 0");
+        }
         this.key = Objects.requireNonNull(key, "key parameter must not be null");
         this.dataType = Objects.requireNonNull(dataType, "dataType parameter must not be null");
         this.data = data;
         this.dataSize = dataSize;
         this.returnSize = returnSize;
         this.sensitive = sensitive;
+    }
+
+    // Intended to be invoked by decoders.
+    public static OSSL_PARAM of(String key, Type dataType, long dataSize, long returnSize) {
+        return new OSSL_PARAM(key, dataType, null, dataSize, returnSize, false);
+    }
+    public static OSSL_PARAM of(String key, Type dataType, byte[] data, long returnSize) {
+        return new OSSL_PARAM(key, dataType, data, data.length, returnSize, false);
     }
 
     public static OSSL_PARAM of(String key, int data) {

--- a/src/main/java/com/oracle/jipher/internal/openssl/ffm/OsslParam.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/ffm/OsslParam.java
@@ -94,9 +94,7 @@ final class OsslParam {
     static void store(OSSL_PARAM param, MemorySegment paramSeg, long offset, SegmentAllocator allocator) {
         MemorySegment dataSeg;
         if (param.data != null) {
-            if (param.dataSize != param.data.length) {
-                throw new IllegalArgumentException("OSSL_PARAM dataSize (" + param.dataSize + ") is not equal to data buffer size (" + param.data.length + ")");
-            }
+            checkDataSize(param);
             dataSeg = switch (param.dataType) {
                 case NONE, UTF8_PTR, OCTET_PTR -> throw new AssertionError();
                 case INTEGER, UNSIGNED_INTEGER, REAL -> storeNumber(param.data, allocator);
@@ -121,9 +119,7 @@ final class OsslParam {
         long size = 0L;
         if (param.key != null) {
             if (param.data != null) {
-                if (param.dataSize != param.data.length) {
-                    throw new IllegalArgumentException("OSSL_PARAM dataSize (" + param.dataSize + ") is not equal to data buffer size (" + param.data.length + ")");
-                }
+                checkDataSize(param);
                 size = switch (param.dataType) {
                     case INTEGER, UNSIGNED_INTEGER, REAL -> param.dataSize + Long.BYTES - 1L;
                     case UTF8_STRING -> param.dataSize + 1L;
@@ -138,6 +134,12 @@ final class OsslParam {
             }
         }
         return size;
+    }
+
+    static void checkDataSize(OSSL_PARAM param) {
+        if (param.dataSize != param.data.length) {
+            throw new IllegalArgumentException("OSSL_PARAM dataSize (" + param.dataSize + ") is not equal to data buffer size (" + param.data.length + ")");
+        }
     }
 
     static MemorySegment storeNumber(byte[] data, SegmentAllocator allocator) {

--- a/src/main/java/com/oracle/jipher/internal/openssl/ffm/OsslParam.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/ffm/OsslParam.java
@@ -93,8 +93,10 @@ final class OsslParam {
 
     static void store(OSSL_PARAM param, MemorySegment paramSeg, long offset, SegmentAllocator allocator) {
         MemorySegment dataSeg;
-        long dataSize = param.dataSize;
         if (param.data != null) {
+            if (param.dataSize != param.data.length) {
+                throw new IllegalArgumentException("OSSL_PARAM dataSize (" + param.dataSize + ") is not equal to data buffer size (" + param.data.length + ")");
+            }
             dataSeg = switch (param.dataType) {
                 case NONE, UTF8_PTR, OCTET_PTR -> throw new AssertionError();
                 case INTEGER, UNSIGNED_INTEGER, REAL -> storeNumber(param.data, allocator);
@@ -111,7 +113,7 @@ final class OsslParam {
         OSSL_PARAM_KEY_HANDLE.set(paramSeg, offset, constString(param.key));
         OSSL_PARAM_DATA_TYPE_HANDLE.set(paramSeg, offset, param.dataType.ordinal());
         OSSL_PARAM_DATA_HANDLE.set(paramSeg, offset, dataSeg);
-        OSSL_PARAM_DATA_SIZE_HANDLE.set(paramSeg, offset, dataSize);
+        OSSL_PARAM_DATA_SIZE_HANDLE.set(paramSeg, offset, param.dataSize);
         OSSL_PARAM_RETURN_SIZE_HANDLE.set(paramSeg, offset, PARAM_UNMODIFIED);
     }
 
@@ -119,14 +121,17 @@ final class OsslParam {
         long size = 0L;
         if (param.key != null) {
             if (param.data != null) {
-                size += switch (param.dataType) {
+                if (param.dataSize != param.data.length) {
+                    throw new IllegalArgumentException("OSSL_PARAM dataSize (" + param.dataSize + ") is not equal to data buffer size (" + param.data.length + ")");
+                }
+                size = switch (param.dataType) {
                     case INTEGER, UNSIGNED_INTEGER, REAL -> param.dataSize + Long.BYTES - 1L;
                     case UTF8_STRING -> param.dataSize + 1L;
                     case OCTET_STRING -> param.dataSize;
                     case NONE, UTF8_PTR, OCTET_PTR -> throw new AssertionError();
                 };
             } else {
-                size += switch (param.dataType) {
+                size = switch (param.dataType) {
                     case UTF8_PTR, OCTET_PTR -> C_POINTER.byteSize() + C_POINTER.byteAlignment() - 1;
                     default -> param.dataSize + Long.BYTES - 1;
                 };
@@ -203,7 +208,6 @@ final class OsslParam {
         long dataSize = (long) OSSL_PARAM_DATA_SIZE_HANDLE.get(paramSeg, offset);
         long returnSize = (long) OSSL_PARAM_RETURN_SIZE_HANDLE.get(paramSeg, offset);
         MemorySegment dataSeg = (MemorySegment) OSSL_PARAM_DATA_HANDLE.get(paramSeg, offset);
-        byte[] data = null;
         if (!useReturnSize || returnSize != PARAM_UNMODIFIED) {
             if ((dataType == Type.UTF8_PTR || dataType == Type.OCTET_PTR) && dataSeg.address() != 0L) {
                 // Dereference the pointer.
@@ -211,14 +215,15 @@ final class OsslParam {
             }
             if (dataSeg.address() != 0L) {
                 dataSeg = dataSeg.asSlice(0L, useReturnSize ? returnSize : dataSize);
-                data = switch (dataType) {
+                byte[] data = switch (dataType) {
                     case NONE -> throw new AssertionError();
                     case INTEGER, UNSIGNED_INTEGER, REAL -> loadNumber(dataSeg);
                     case UTF8_STRING, UTF8_PTR, OCTET_STRING, OCTET_PTR -> dataSeg.toArray(JAVA_BYTE);
                 };
+                return OSSL_PARAM.of(key, dataType, data, returnSize);
             }
         }
-        return new OSSL_PARAM(key, dataType, data, dataSize, returnSize, false);
+        return OSSL_PARAM.of(key, dataType, dataSize, returnSize);
     }
 
     static byte[] loadNumber(MemorySegment dataSeg) {

--- a/src/main/java/com/oracle/jipher/internal/openssl/ffm/OsslParam.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/ffm/OsslParam.java
@@ -129,13 +129,14 @@ final class OsslParam {
             } else {
                 size = switch (param.dataType) {
                     case UTF8_PTR, OCTET_PTR -> C_POINTER.byteSize() + C_POINTER.byteAlignment() - 1;
-                    default -> param.dataSize + Long.BYTES - 1;
+                    default -> Math.addExact(param.dataSize, Long.BYTES - 1);
                 };
             }
         }
         return size;
     }
 
+    // This should only be called when param.data != null.
     static void checkDataSize(OSSL_PARAM param) {
         if (param.dataSize != param.data.length) {
             throw new IllegalArgumentException("OSSL_PARAM dataSize (" + param.dataSize + ") is not equal to data buffer size (" + param.data.length + ")");

--- a/src/main/java/com/oracle/jipher/internal/openssl/ffm/OsslParamBufferImpl.java
+++ b/src/main/java/com/oracle/jipher/internal/openssl/ffm/OsslParamBufferImpl.java
@@ -188,9 +188,9 @@ public final class OsslParamBufferImpl implements OsslParamBuffer {
             ++paramCount;
             long bufSize = calcBufferMemoryRequirement(param);
             if (param.sensitive) {
-                totalSensitiveBufSize += bufSize;
+                totalSensitiveBufSize = Math.addExact(totalSensitiveBufSize, bufSize);
             } else {
-                totalBufSize += bufSize;
+                totalBufSize = Math.addExact(totalBufSize, bufSize);
             }
         }
         totalBufSize += (paramCount + 1L) * C_OSSL_PARAM_SIZE;


### PR DESCRIPTION
Ensure OSSL_PARAM dataSize matches data.length when storing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [BRISBANE-54](https://bugs.openjdk.org/browse/BRISBANE-54): Ensure OSSL_PARAM dataSize is valid for store operations (**Bug** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**) ⚠️ Review applies to [19926948](https://git.openjdk.org/brisbane/pull/17/files/199269486e35f5864dcda1ee5f0eb623c4fc7bec)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**) ⚠️ Review applies to [19926948](https://git.openjdk.org/brisbane/pull/17/files/199269486e35f5864dcda1ee5f0eb623c4fc7bec)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/brisbane.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/17.diff">https://git.openjdk.org/brisbane/pull/17.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/17#issuecomment-5199484070)
</details>
