### PR TITLE
59: Add tagging constraints to .jcheck file

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -48,7 +48,7 @@ error=author,committer,reviewers,merge,issues,executable,symlink,message,whitesp
 warning=issuestitle,binary
 
 [repository]
-tags=(?:\\d{2}(?:\\.\\d+)+\\+\\d{1,2}|\\d{2}(?:\\.\\d+)?-ga)
+tags=(?:[1-9]\d*(?:\.\d+)*(?:\+\d+|-ga))
 branches=.*
 
 [census]

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -48,8 +48,7 @@ error=author,committer,reviewers,merge,issues,executable,symlink,message,whitesp
 warning=issuestitle,binary
 
 [repository]
-; if promotion will tag... uncomment and update
-; tags= <regex of tag format>
+tags=(?:\\d{2}(?:\\.\\d+)+\\+\\d{1,2}|\\d{2}(?:\\.\\d+)?-ga)
 branches=.*
 
 [census]


### PR DESCRIPTION
Added tagging constraints to match these tag types:

Release candidate: n+m (n is concise version number, m is build number)
Release: n-ga

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [BRISBANE-59](https://bugs.openjdk.org/browse/BRISBANE-59): Add tagging constraints to .jcheck file (**Task** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/brisbane.git pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/18.diff">https://git.openjdk.org/brisbane/pull/18.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/18#issuecomment-5435689685)
</details>
