### PR TITLE
62: Update jcheck config with release version

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -41,7 +41,7 @@
 [general]
 project=brisbane
 jbs=BRISBANE
-version=20-ea
+version=20
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,whitespace


### PR DESCRIPTION
Prepare for 20 GA release

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [BRISBANE-62](https://bugs.openjdk.org/browse/BRISBANE-62): Update jcheck config with release version (**Task** - P4)


### Reviewers
 * [Lars Malmborg](https://openjdk.org/census#lmalmborg) (@lars-oracle - Committer)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/brisbane.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/19.diff">https://git.openjdk.org/brisbane/pull/19.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/19#issuecomment-5447042021)
</details>
