### PR TITLE
63: Update Jipher version to 20.1

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -41,7 +41,7 @@
 [general]
 project=brisbane
 jbs=BRISBANE
-version=20
+version=20.1
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,whitespace

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ javadoc {
 }
 
 group = 'brisbane.jipher'
-version = findProperty('ProjVersion') ?: '20.0'
+version = findProperty('ProjVersion') ?: '20.1'
 
 tasks.withType(JavaCompile).configureEach {
     options.release = 25


### PR DESCRIPTION
Update Jipher version to 20.1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [BRISBANE-63](https://bugs.openjdk.org/browse/BRISBANE-63): Update Jipher version to 20.1 (**Task** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/brisbane.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/20.diff">https://git.openjdk.org/brisbane/pull/20.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/20#issuecomment-5520780690)
</details>
