### PR TITLE
66: Correct size of output buffer used to receive AES-KWP unwrap output

### DIFF
--- a/src/intTest/java/com/oracle/test/integration/symciph/WrapCipherTest.java
+++ b/src/intTest/java/com/oracle/test/integration/symciph/WrapCipherTest.java
@@ -47,10 +47,12 @@ import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
+import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -219,6 +221,25 @@ public class WrapCipherTest {
         } catch (NoSuchAlgorithmException e) {
             // Expected.
         }
+    }
+
+    @Test
+    public void decryptDoFinalShortBufferRetry() throws Exception {
+        Cipher c = getInitCipher(Cipher.DECRYPT_MODE);
+
+        byte[] input = tv.getCiphertext();
+        byte[] expectedOutput = tv.getData();
+        byte[] output = new byte[expectedOutput.length - 1];
+
+        try {
+            c.doFinal(input, 0, input.length, output, 0);
+            fail("Failed to throw ShortBufferException");
+        } catch (ShortBufferException e) {
+            output = Arrays.copyOf(output, expectedOutput.length);
+            int outputLen = c.doFinal(input, 0, input.length, output, 0);
+            output = Arrays.copyOf(output, outputLen);
+        }
+        assertArrayEquals(expectedOutput, output);
     }
 
     @Test(expected = IllegalBlockSizeException.class)

--- a/src/main/java/com/oracle/jipher/internal/spi/WrapCipher.java
+++ b/src/main/java/com/oracle/jipher/internal/spi/WrapCipher.java
@@ -50,7 +50,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.ProviderException;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
-import java.util.Arrays;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
@@ -196,7 +195,6 @@ public abstract class WrapCipher extends SymmCipher {
         }
 
         byte[] outputBounceBuffer = null;
-        byte[] savedOutputData = null;
         boolean doCleanup = true;
         try {
             int position = this.state != null ? this.state.inputBuffer.position() : 0;
@@ -212,12 +210,14 @@ public abstract class WrapCipher extends SymmCipher {
                 }
             }
 
-            // If decrypting in KWP mode and the actual output size could be greater than available space
-            // in the output buffer, allocate a temporary bounce-buffer to receive the output.
+            // If decrypting in KWP mode, allocate a temporary bounce-buffer to receive the output.
             byte[] outBuf;
             int outBufOffset;
-            if (!this.encrypt && this.mode == KWP && outputSize > out.length - outOffset) {
-                outputBounceBuffer = new byte[outputSize];
+            if (!this.encrypt && this.mode == KWP) {
+                // Since OpenSSL's KWP unwrap failure cleanup can write up to one unit beyond the documented
+                // plaintext maximum, use an internal guarded buffer with one-unit (8-byte) guard space when
+                // doing KWP decrypt.
+                outputBounceBuffer = new byte[outputSize + UNIT_BYTES];
 
                 // Output to the output bounce-buffer.
                 outBuf = outputBounceBuffer;
@@ -226,25 +226,6 @@ public abstract class WrapCipher extends SymmCipher {
                 // Output directly to the application-supplied output buffer.
                 outBuf = out;
                 outBufOffset = outOffset;
-
-                // Check for KWP decryption mode.
-                if (minOutputSize < outputSize) {
-                    // When decrypting in KWP mode, if the plaintext is not a multiple of 8 bytes
-                    // then, as an optimization, OpenSSL will write the final 8-byte unit to the
-                    // output buffer complete with the padding bytes (bytes with value zero that
-                    // follow the plaintext to pad it out to a multiple of the 8-byte unit size)
-                    // and then indicate the plaintext size as the amount of output it has produced.
-                    // Although modifying data in the output buffer within the bounds of
-                    // the size returned by engineGetOutputSize() but past the reported output size
-                    // is not explicitly disallowed by javax.crypto.Cipher, doing so deviates from
-                    // the behavior of other existing JCA/JCE providers.
-                    //
-                    // To ensure good interoperability and conform to a strict interpretation of the
-                    // javax.crypto.Cipher JavaDoc, save data in the application's output buffer
-                    // that may be overwritten by OpenSSL's aes-wrap-pad implementation so that it
-                    // can be restored after calling ctx.update().
-                    savedOutputData = Arrays.copyOfRange(outBuf, outBufOffset + minOutputSize, outBufOffset + outputSize);
-                }
             }
 
             // If there is some data buffered in this.state.inputBuffer then use that buffer as the source
@@ -266,10 +247,6 @@ public abstract class WrapCipher extends SymmCipher {
             // Note that while it looks like OpenSSL does not require EVP_CipherFinal_ex to be called
             // for id-aes-wrap and id-aes-wrap-pad, we call it anyway.
             outLen += ctx.doFinal(outBuf, outBufOffset + outLen);
-            if (outLen < outputSize && outLen >= minOutputSize && savedOutputData != null) {
-                // Restore data in the output buffer that was overwritten by padding bytes.
-                System.arraycopy(savedOutputData, outLen - minOutputSize, outBuf, outBufOffset + outLen, outputSize - outLen);
-            }
             if (outLen > outBuf.length - outBufOffset) {
                 throw new AssertionError("Internal error: buffer overrun");
             }
@@ -302,7 +279,6 @@ public abstract class WrapCipher extends SymmCipher {
             }
         } finally {
             Util.clearArray(outputBounceBuffer);
-            Util.clearArray(savedOutputData);
             if (doCleanup) {
                 cleanup();
             }

--- a/src/test/java/com/oracle/jipher/internal/spi/WrapCipherTest.java
+++ b/src/test/java/com/oracle/jipher/internal/spi/WrapCipherTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.oracle.jipher.internal.spi;
+
+import java.util.Arrays;
+import javax.crypto.BadPaddingException;
+import javax.crypto.ShortBufferException;
+
+import org.junit.Test;
+
+import com.oracle.jipher.internal.openssl.CipherCtx;
+import com.oracle.jipher.internal.openssl.OpenSslException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WrapCipherTest {
+
+    @Test
+    public void kwpUnwrapGuardedInternalBuffer() throws Exception {
+        WrapCipher cipher = new WrapCipher.AesWrapPad();
+        CipherCtx ctx = mock(CipherCtx.class);
+
+        cipher.ctx = ctx;
+        cipher.initialized = true;
+        cipher.encrypt = false;
+
+        // Handle to retain buffer captured in closure
+        final byte[][] capturedOutBuffer = new byte[1][];
+
+        // Set just a few of the bytes to allow both that these are set and that the remaining bytes is retained
+        when(ctx.update(any(), anyInt(), anyInt(), any(), anyInt())).thenAnswer(invocation -> {
+            byte[] outBuf = invocation.getArgument(3);
+            int outOffset = invocation.getArgument(4);
+            capturedOutBuffer[0] = outBuf;
+            outBuf[outOffset] = 1;
+            outBuf[outOffset + 1] = 2;
+            return 2;
+        });
+        when(ctx.doFinal(any(), anyInt())).thenReturn(0);
+
+        byte[] in = new byte[16];
+        byte[] out = new byte[8];
+        Arrays.fill(out, (byte) 0x55);
+
+        int outLen = cipher.engineDoFinal(in, 0, in.length, out, 0);
+
+        // Check that the bytes expected to be set are the expected values
+        assertEquals(2, outLen);
+        assertArrayEquals(new byte[]{1, 2}, Arrays.copyOf(out, outLen));
+
+        // Check that the remaining buffer is retained
+        assertEquals((byte) 0x55, out[outLen]);
+
+        // Check that the bounce buffer in KWP unwrap is different to the passed in out buffer
+        assertNotSame(out, capturedOutBuffer[0]);
+
+        // Check that the bounce buffer in KWP unwrap is the actual out buffer size 8 + 8-byte guard
+        assertEquals(16, capturedOutBuffer[0].length);
+
+        // Check that the bounce buffer is a new, cleared buffer (relying on implicit zeroization of buffers)
+        assertArrayEquals(capturedOutBuffer[0], new byte[capturedOutBuffer[0].length]);
+    }
+
+    @Test
+    public void kwpUnwrapErrorLeavesOutputUnchanged() throws Exception {
+        WrapCipher cipher = new WrapCipher.AesWrapPad();
+        CipherCtx ctx = mock(CipherCtx.class);
+
+        cipher.ctx = ctx;
+        cipher.initialized = true;
+        cipher.encrypt = false;
+
+        when(ctx.update(any(), anyInt(), anyInt(), any(), anyInt())).thenAnswer(invocation -> {
+            byte[] outBuf = invocation.getArgument(3);
+            int outOffset = invocation.getArgument(4);
+            // Fill buffer with something entirely different
+            Arrays.fill(outBuf, outOffset, outOffset + 16, (byte) 0xAA);
+            return 2;
+        });
+        when(ctx.doFinal(any(), anyInt())).thenThrow(new OpenSslException("forced error"));
+
+        byte[] in = new byte[16];
+        byte[] out = new byte[16];
+        Arrays.fill(out, (byte) 0x55);
+        byte[] expectedOut = out.clone();
+
+        try {
+            cipher.engineDoFinal(in, 0, in.length, out, 0);
+            fail("Expected engineDoFinal to fail and throw BadPaddingException");
+        } catch (BadPaddingException expected) {
+            // Ensure the caller's output buffer is unchanged after BadPaddingException.
+            assertArrayEquals(expectedOut, out);
+        }
+    }
+
+    @Test
+    public void kwpUnwrapShortBufferLeavesOutputUnchanged() throws Exception {
+        WrapCipher cipher = new WrapCipher.AesWrapPad();
+        CipherCtx ctx = mock(CipherCtx.class);
+
+        cipher.ctx = ctx;
+        cipher.initialized = true;
+        cipher.encrypt = false;
+
+        when(ctx.update(any(), anyInt(), anyInt(), any(), anyInt())).thenAnswer(invocation -> {
+            byte[] outBuf = invocation.getArgument(3);
+            int outOffset = invocation.getArgument(4);
+            outBuf[outOffset] = 1;
+            outBuf[outOffset + 1] = 2;
+            return 2;
+        });
+        when(ctx.doFinal(any(), anyInt())).thenReturn(0);
+
+        byte[] in = new byte[16];
+        byte[] out = new byte[1];
+        Arrays.fill(out, (byte) 0x55);
+        byte[] expectedOut = out.clone();
+
+        try {
+            cipher.engineDoFinal(in, 0, in.length, out, 0);
+            fail("Expected engineDoFinal to fail and throw ShortBufferException");
+        } catch (ShortBufferException expected) {
+            // Ensure the caller's output buffer is unchanged after ShortBufferException.
+            assertArrayEquals(expectedOut, out);
+        }
+
+        byte[] largeOut = new byte[2];
+        int outLen = cipher.engineDoFinal(in, 0, in.length, largeOut, 0);
+        assertEquals(2, outLen);
+        assertArrayEquals(new byte[]{1, 2}, largeOut);
+    }
+}


### PR DESCRIPTION
Correct size of output buffer used to receive AES-KWP unwrap output

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [BRISBANE-66](https://bugs.openjdk.org/browse/BRISBANE-66): Correct size of output buffer used to receive AES-KWP unwrap output (**Bug** - P4)


### Reviewers
 * [Eamon ODea](https://openjdk.org/census#eodea) (@eodie - **Reviewer**) ⚠️ Review applies to [ca554e07](https://git.openjdk.org/brisbane/pull/21/files/ca554e0792caea9b1f5dde26ef211536a744cde1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/brisbane.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/brisbane.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/brisbane/pull/21.diff">https://git.openjdk.org/brisbane/pull/21.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/brisbane/pull/21#issuecomment-5612131072)
</details>
